### PR TITLE
Development

### DIFF
--- a/wp-content/themes/debtcollective/inc/block-editor/block-styles.php
+++ b/wp-content/themes/debtcollective/inc/block-editor/block-styles.php
@@ -22,5 +22,5 @@ namespace DebtCollective\Inc;
  * 
  * @see https://developer.wordpress.org/reference/functions/unregister_block_style/
  */
-\unregister_block_style( 'core/button', 'fill' );
-\unregister_block_style( 'core/button', 'outline' );
+// \unregister_block_style( 'core/button', 'fill' );
+// \unregister_block_style( 'core/button', 'outline' );


### PR DESCRIPTION
Commenting out in order to fix warning:

```sh
Notice: WP_Block_Styles_Registry::unregister was called incorrectly. Block "core/button" does not contain a style named "fill". Please see Debugging in WordPress for more information. (This message was added in version 5.3.0.) in /var/www/html/wp-includes/functions.php on line 5663 Notice: WP_Block_Styles_Registry::unregister was called incorrectly. Block "core/button" does not contain a style named "outline". Please see Debugging in WordPress for more information. (This message was added in version 5.3.0.) in /var/www/html/wp-includes/functions.php on line 5663
```

@todo troubleshoot this. `fill` style does exist per:

https://github.com/WordPress/gutenberg/blob/trunk/packages/block-library/src/button/block.json