### PR TITLE
Development

### DIFF
--- a/wp-content/plugins/site-functionality/src/api/class-rest-api.php
+++ b/wp-content/plugins/site-functionality/src/api/class-rest-api.php
@@ -41,8 +41,9 @@ class RestAPI extends Base {
 	public function register_routes() {
 		\register_rest_route( self::API_NAMESPACE, '/roles', 
 			[
-				'methods' => 'GET',
-				'callback' => [ $this, 'get_user_roles' ],
+				'methods' 				=> 'GET',
+				'callback' 				=> [ $this, 'get_user_roles' ],
+				'permission_callback' 	=> \__return_true(),
 			]
 		);
 	}


### PR DESCRIPTION
```
Notice: register_rest_route was called incorrectly. The REST API route definition for site-functionality/v1/rolespermission_callback is missing the required argument. For REST API routes that are intended to be public, use __return_true as the permission callback. Please see Debugging in WordPress for more information. (This message was added in version 5.5.0.) in /var/www/html/wp-includes/functions.php on line 5663
```