### PR TITLE
Update routing and templates

### DIFF
--- a/wp-content/plugins/site-functionality/blocks/src/templates/purchase_agreement.php
+++ b/wp-content/plugins/site-functionality/blocks/src/templates/purchase_agreement.php
@@ -45,7 +45,7 @@ $taxonomy = $data->args['taxonomy'];
 					<?php \esc_html_e( 'Abolished', 'site-functionality' ); ?>
 				</dt>
 				<dd class="purchase-agreement__amount entry-value">
-					<?php \printf( '<span class="currency-symbol">%s</span><span class="value">%s</span>', __( '$', 'debtcollecollective' ), number_format( $amount ) ); ?>
+					<?php \printf( '<span class="currency-symbol">%s</span><span class="value">%s</span>', __( '$', 'debtcollecollective' ), number_format( $amount, 2 ) ); ?>
 				</dd>
 			<?php endif; ?>
 			<?php if( \has_term( '', $taxonomy, $post_id ) ) : 
@@ -54,7 +54,7 @@ $taxonomy = $data->args['taxonomy'];
 					<?php \esc_html_e( 'Type', 'site-functionality' ); ?>
 				</dt>
 				<dd class="purchase-agreement__type entry-value">
-					<?php echo \esc_html( $tags[0] ); ?>
+					<?php echo implode( '<span class="separator">/</span>', $tags ); ?>
 				</dd>
 			<?php endif; ?>
 			<?php if( $number = \get_post_meta( $post_id, 'number', true ) ) : ?>
@@ -70,7 +70,7 @@ $taxonomy = $data->args['taxonomy'];
 					<?php \esc_html_e( 'Average Debt/Debtor', 'site-functionality' ); ?>
 				</dt>
 				<dd class="purchase-agreement__average entry-value">
-					<?php printf( '<span class="currency-symbol">%s</span><span class="value">%s</span>', __( '$', 'debtcollecollective' ), number_format( $average ) ); ?>
+					<?php printf( '<span class="currency-symbol">%s</span><span class="value">%s</span>', __( '$', 'debtcollecollective' ), number_format( $average, 2 ) ); ?>
 				</dd>
 			<?php endif; ?>
 			<?php if( $purchase_price = \get_post_meta( $post_id, 'price', true ) ) : ?>

--- a/wp-content/plugins/site-functionality/src/abstracts/class-post-type.php
+++ b/wp-content/plugins/site-functionality/src/abstracts/class-post-type.php
@@ -88,6 +88,10 @@ abstract class PostType extends Base {
 			'filter_items_list'     => sprintf( /* translators: %s: post type title */ __( 'Filter %s list', 'wp-action-network-events' ), strtolower( $this::POST_TYPE['title'] ) ),
 			'featured_image'        => __( 'Featured Image', 'wp-action-network-events' ),
 		);
+		$rewrite = [
+			'slug'       => $this::POST_TYPE['archive'],
+			'with_front' => $this::POST_TYPE['with_front'],
+		];
 		$args = array(
 			'label'                 => $this::POST_TYPE['title'],
 			'labels'                => $labels,
@@ -102,11 +106,8 @@ abstract class PostType extends Base {
 			'show_in_admin_bar'     => true,
 			'show_in_nav_menus'     => true,
 			'can_export'            => true,
-			'has_archive'        	=> $this::POST_TYPE['archive'],
-			'rewrite'            => [
-				'slug'       => $this::POST_TYPE['archive'],
-				'with_front' => true,
-			],
+			'has_archive'        	=> $this::POST_TYPE['has_archive'],
+			'rewrite'            	=> $rewrite,
 			'exclude_from_search'   => false,
 			'publicly_queryable'    => true,
 			'capability_type'       => 'post',

--- a/wp-content/plugins/site-functionality/src/abstracts/class-taxonomy.php
+++ b/wp-content/plugins/site-functionality/src/abstracts/class-taxonomy.php
@@ -78,6 +78,11 @@ abstract class Taxonomy extends Base {
 			'items_list_navigation'      => sprintf( /* translators: %s: post type title */ __( '%s list navigation', 'wp-action-network-events' ), $this::TAXONOMY['title'] ),
 		);
 
+		$rewrite = [
+			'slug'						=> $this::TAXONOMY['archive'],
+			'with_front'				=> $this::TAXONOMY['with_front']
+		];
+
 		$args = array(
 			'labels'                     => $labels,
 			'hierarchical'               => false,
@@ -86,13 +91,14 @@ abstract class Taxonomy extends Base {
 			'show_admin_column'          => true,
 			'show_in_nav_menus'          => true,
 			'show_tagcloud'              => true,
+			'rewrite'					 => $rewrite,
 			'show_in_rest'               => true,
 			'rest_base'             	 => $this::TAXONOMY['rest'],
 		);
 		\register_taxonomy( 
 			$this::TAXONOMY['id'], 
 			$this::TAXONOMY['post_types'], 
-			\apply_filters( \get_class( $this ) . '\Args', $args ) 
+			\apply_filters( \get_class( self ) . '\Args', $args ) 
 		);
 	}
 }

--- a/wp-content/plugins/site-functionality/src/post-types/class-purchase-agreement.php
+++ b/wp-content/plugins/site-functionality/src/post-types/class-purchase-agreement.php
@@ -21,12 +21,14 @@ class PurchaseAgreement extends PostType {
 	 */
 	public const POST_TYPE = [
 		'id'       		=> 'purchase_agreement',
-		'archive'  		=> 'purchase-agreements',
 		'menu'    		=> 'Purchase Agreements',
 		'title'    		=> 'Agreements',
 		'singular' 		=> 'Agreement',
 		'icon'     		=> 'dashicons-bank',
 		'taxonomies'	=> [ 'purchase_agreement_type' ],
+		'has_archive'  	=> 'purchase-agreements',
+		'with_front'  	=> false,
+		'archive'  		=> 'purchase-agreements',
 		'rest_base'		=> 'purchase-agreements',
 	];
 

--- a/wp-content/plugins/site-functionality/src/taxonomies/class-purchase-agreement-type.php
+++ b/wp-content/plugins/site-functionality/src/taxonomies/class-purchase-agreement-type.php
@@ -7,6 +7,7 @@
 namespace Site_Functionality\Taxonomies;
 
 use Site_Functionality\Abstracts\Taxonomy;
+use Site_Functionality\PostTypes\PurchaseAgreement as PurchaseAgreement;
 
 /**
  * Class Taxonomies
@@ -21,12 +22,37 @@ class PurchaseAgreementType extends Taxonomy {
 	 */
 	public const TAXONOMY = [
 		'id'       		=> 'purchase_agreement_type',
-		'archive'  		=> 'purchase-types',
 		'title'    		=> 'Purchase Agreement Types',
 		'singular' 		=> 'Purchase Agreement Type',
 		'menu'			=> 'Types',
 		'post_types' 	=> [ 'purchase_agreement' ],
-		'rest'			=> 'purchase-types'
+		'has_archive'	=> 'purchase-agreements/type',
+		'archive'  		=> 'purchase-agreements/type',
+		'with_front'	=> false,
+		'rest'			=> 'purchase-types',
 	];
+
+	/** 
+	 * Constructor.
+	 *
+	 * @since 1.0.0
+	 */
+	public function __construct( $version, $plugin_name ) {
+	   parent::__construct( $version, $plugin_name );
+
+	   \add_action( 'init', [ $this, 'rewrite_rules' ], 10, 0 );
+	}
+
+	/**
+	 * Add rewrite rules
+	 * 
+	 * @link https://developer.wordpress.org/reference/functions/add_rewrite_rule/
+	 *
+	 * @return void
+	 */
+	public function rewrite_rules() {
+		\add_rewrite_rule( self::TAXONOMY['archive'] . '/([^/]+)/page/([0-9]{1,})/?', 'index.php?taxonomy=' . self::TAXONOMY['id'] . '&term=$matches[1]&post_type=' . PurchaseAgreement::POST_TYPE['id'] . '&paged=$matches[2]', 'top' );
+		\add_rewrite_rule( self::TAXONOMY['archive'] . '/([^/]+)/?', 'index.php?taxonomy=' . self::TAXONOMY['id'] . '&term=$matches[1]&post_type=' . PurchaseAgreement::POST_TYPE['id'], 'top' );
+	}
 
 }

--- a/wp-content/themes/debtcollective/template-parts/content-purchase_agreement.php
+++ b/wp-content/themes/debtcollective/template-parts/content-purchase_agreement.php
@@ -45,7 +45,7 @@ $taxonomy = 'purchase_agreement_type';
 					<?php \esc_html_e( 'Abolished', 'debtcollective' ); ?>
 				</dt>
 				<dd class="purchase-agreement__amount entry-value">
-					<?php \printf( '<span class="currency-symbol">%s</span><span class="value">%s</span>', __( '$', 'debtcollecollective' ), number_format( $amount ) ); ?>
+					<?php \printf( '<span class="currency-symbol">%s</span><span class="value">%s</span>', __( '$', 'debtcollecollective' ), number_format( $amount, 2 ) ); ?>
 				</dd>
 			<?php endif; ?>
 			<?php if( \has_term( '', $taxonomy, $post_id ) ) : 
@@ -54,7 +54,7 @@ $taxonomy = 'purchase_agreement_type';
 					<?php \esc_html_e( 'Type', 'debtcollective' ); ?>
 				</dt>
 				<dd class="purchase-agreement__type entry-value">
-					<?php echo \esc_html( $tags[0] ); ?>
+					<?php echo implode( '<span class="separator">/</span>', $tags ); ?>
 				</dd>
 			<?php endif; ?>
 			<?php if( $number = \get_post_meta( $post_id, 'number', true ) ) : ?>
@@ -70,7 +70,7 @@ $taxonomy = 'purchase_agreement_type';
 					<?php \esc_html_e( 'Average Debt/Debtor', 'debtcollective' ); ?>
 				</dt>
 				<dd class="purchase-agreement__average entry-value">
-					<?php printf( '<span class="currency-symbol">%s</span><span class="value">%s</span>', __( '$', 'debtcollecollective' ), number_format( $average ) ); ?>
+					<?php printf( '<span class="currency-symbol">%s</span><span class="value">%s</span>', __( '$', 'debtcollecollective' ), number_format( $average, 2 ) ); ?>
 				</dd>
 			<?php endif; ?>
 			<?php if( $purchase_price = \get_post_meta( $post_id, 'price', true ) ) : ?>


### PR DESCRIPTION
Update routing
- Update paths to serve at:
   - All Posts: `/purchase-agreements/`
   - All  Term Posts:`/purchase-agreements/type/`
- Add archive vars to post type and taxonomy abstract
- Update archive values
- Add rewrite for taxonomy

Update Templates
- Make number format consistent (2 decimals)
- Display multiple tags separated by `/`