### PR TITLE
Merge fix to staging for deployment to test

### DIFF
--- a/wp-content/plugins/site-functionality/src/abstracts/class-taxonomy.php
+++ b/wp-content/plugins/site-functionality/src/abstracts/class-taxonomy.php
@@ -98,7 +98,7 @@ abstract class Taxonomy extends Base {
 		\register_taxonomy( 
 			$this::TAXONOMY['id'], 
 			$this::TAXONOMY['post_types'], 
-			\apply_filters( \get_class( self ) . '\Args', $args ) 
+			\apply_filters( \get_class( $this ) . '\Args', $args ) 
 		);
 	}
 }


### PR DESCRIPTION
`Warning: Use of undefined constant self - assumed 'self' (this will throw an Error in a future version of PHP) in /var/www/html/wp-content/plugins/site-functionality/src/abstracts/class-taxonomy.php on line 101 Warning: get_class() expects parameter 1 to be object, string given in /var/www/html/wp-content/plugins/site-functionality/src/abstracts/class-taxonomy.php on line 101`