### PR TITLE
Hotfix - Fix typo causing PHP warning

### DIFF
--- a/wp-content/themes/debtcollective/template-parts/content-an_event.php
+++ b/wp-content/themes/debtcollective/template-parts/content-an_event.php
@@ -9,7 +9,7 @@
 $post_id  = get_the_ID();
 $taxonomy = 'event_tag';
 
-$date_format          = \has_term( [ 'welcome-call', 'welcome-calls' ], $taxonomy, $post_idl ) ? 'D, M j' : 'l F j, Y';
+$date_format          = \has_term( [ 'welcome-call', 'welcome-calls' ], $taxonomy, $post_id ) ? 'D, M j' : 'l F j, Y';
 $time_format          = 'g:ia';
 $default_timezone     = \get_option( 'timezone_string' );
 $timezone             = \get_post_meta( $post_id, 'timezone', true ) ?? $default_timezone;


### PR DESCRIPTION
`Notice: Undefined variable: post_idl in /var/www/html/wp-content/themes/debtcollective/template-parts/content-an_event.php on line 12`
